### PR TITLE
Added solution without map()

### DIFF
--- a/src/pages/certifications/javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals/index.md
+++ b/src/pages/certifications/javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals/index.md
@@ -31,3 +31,9 @@ It's required to use template literals to return a list as every element in the 
 
 ```const resultDisplayArray = arr.map(item => `<li class="text-warning">${item}</li>`);```
 
+## No map() solution
+Despite it's a less flexible solution, if you know the number of elements in advance, you can enumerate them as in
+
+```const resultDisplayArray = [`<li class="text-warning">${result.failure[0]}</li>`,
+  `<li class="text-warning">${result.failure[1]}</li>`
+  ,`<li class="text-warning">${result.failure[2]}</li>`];```


### PR DESCRIPTION
Despite the test suite does not validate this solution, it's worth noting that the solution proposed should be working as it respects all test enouncements

Replace this sentence with a brief description of the awesome changes your PR has. 😊

---

<!-- Thank you for contributing to the `guides` repo, it is much appreciated! 😊 -->

<!--

Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

-->

## ✅️ By submitting this PR, I have verified the following

- [x] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md` since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Other examples are **Git: edit Git Commit article** or **PHP: create PHP section and add Data Structures article**
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.

<!-- TO NOTE

1. Avoid a duplicate PR by searching through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes.

2. If you edit a stub article, your changes are substantial enough to justify removing the stub text ("This article is a stub..." part).

We can't accept PRs that only add links to the "More Information" section - a repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file.

3. Your changes must pass the Travis CI build.

Any new folder you create in "src/pages" must have an index.md.

All articles must have the following as the first three lines in the file:

---
title: Article title goes here
---

-->
